### PR TITLE
OpenClaw integration + OpenRouter support (OpenAI-compatible base_url)

### DIFF
--- a/api/app/auth.py
+++ b/api/app/auth.py
@@ -17,16 +17,35 @@ ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_DAYS = 365
 
 # Password hashing
+# NOTE: bcrypt truncates passwords at 72 bytes. To avoid 500s on long passwords
+# (or when someone accidentally passes an API key), we enforce a max length.
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+_MAX_PASSWORD_BYTES = 72
+
+def _enforce_bcrypt_password_limit(pw: str) -> str:
+    # bcrypt limit is in bytes, not characters
+    if pw is None:
+        return pw
+    b = pw.encode("utf-8")
+    if len(b) > _MAX_PASSWORD_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Password too long for bcrypt (max {_MAX_PASSWORD_BYTES} bytes).",
+        )
+    return pw
+
 security = HTTPBearer(auto_error=False)
 
 class AuthService:
     @staticmethod
     def verify_password(plain_password: str, hashed_password: str) -> bool:
+        plain_password = _enforce_bcrypt_password_limit(plain_password)
         return pwd_context.verify(plain_password, hashed_password)
     
     @staticmethod
     def get_password_hash(password: str) -> str:
+        password = _enforce_bcrypt_password_limit(password)
         return pwd_context.hash(password)
     
     @staticmethod

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -11,7 +11,12 @@ class Settings:
     JWT_EXPIRE_DAYS: int = 365
     
     # Cortex
-    OPENAI_API_KEY: str = os.getenv("OPENAI_API_KEY", "")
+    # OpenAI-compatible key. Prefer OPENAI_API_KEY; fall back to OPENROUTER_API_KEY.
+    OPENAI_API_KEY: str = os.getenv("OPENAI_API_KEY", os.getenv("OPENROUTER_API_KEY", ""))
+
+    # Optional OpenAI-compatible base URL override.
+    # If using OpenRouter, set OPENAI_BASE_URL=https://openrouter.ai/api/v1 (or let code default it).
+    OPENAI_BASE_URL: str = os.getenv("OPENAI_BASE_URL", "")
     CHROMA_URI: str = os.getenv("CHROMA_URI", "http://localhost:7003")
     
     # API

--- a/api/app/services/cortex_service.py
+++ b/api/app/services/cortex_service.py
@@ -20,11 +20,20 @@ class CortexService:
     def _initialize_cortex(self):
         load_dotenv()
         
-        api_key = os.getenv("OPENAI_API_KEY")
+        # OpenAI-compatible key. Prefer OPENAI_API_KEY; fall back to OPENROUTER_API_KEY.
+        api_key = os.getenv("OPENAI_API_KEY") or os.getenv("OPENROUTER_API_KEY")
         chroma_uri = os.getenv("CHROMA_URI", "http://localhost:7003")
+
+        # Optional OpenAI-compatible base URL override.
+        # For OpenRouter: https://openrouter.ai/api/v1
+        openai_base_url = os.getenv("OPENAI_BASE_URL")
+        if not openai_base_url and os.getenv("OPENROUTER_API_KEY") and not os.getenv("OPENAI_API_KEY"):
+            openai_base_url = "https://openrouter.ai/api/v1"
+        if openai_base_url:
+            os.environ["OPENAI_BASE_URL"] = openai_base_url
         
         if not api_key:
-            raise ValueError("OPENAI_API_KEY not found in environment variables")
+            raise ValueError("OPENAI_API_KEY or OPENROUTER_API_KEY not found in environment variables")
         
         try:
             self._memory_system = AgenticMemorySystem(

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -33,3 +33,5 @@ scikit-learn==1.3.2
 openai==1.86.0
 langchain==0.2.0
 httpx==0.28.1
+# Pin bcrypt for passlib compatibility (bcrypt 5.x removed __about__)
+bcrypt>=4.0.1,<4.1

--- a/cortex/embedding_manager.py
+++ b/cortex/embedding_manager.py
@@ -49,16 +49,41 @@ class EmbeddingManager:
             self._init_openai()
 
     def _init_openai(self):
-        """Initialize OpenAI backend"""
+        """Initialize OpenAI-compatible embeddings backend.
+
+        Supports both:
+        - OpenAI direct (OPENAI_API_KEY)
+        - OpenRouter OpenAI-compatible proxy (OPENROUTER_API_KEY) via base_url
+
+        Environment variables:
+        - OPENAI_API_KEY (preferred if set)
+        - OPENROUTER_API_KEY (fallback)
+        - OPENAI_BASE_URL (optional override)
+        """
         try:
             from openai import OpenAI
-            api_key = os.getenv("OPENAI_API_KEY")
+
+            # Prefer a real OpenAI key if present; otherwise fall back to OpenRouter.
+            api_key = os.getenv("OPENAI_API_KEY") or os.getenv("OPENROUTER_API_KEY")
             if not api_key:
-                raise ValueError("OPENAI_API_KEY environment variable is required for OpenAI embeddings")
-            self.client = OpenAI(api_key=api_key)
-            logger.info(f"Created EmbeddingManager for OpenAI model: {self.model_name}")
+                raise ValueError(
+                    "Missing API key: set OPENAI_API_KEY or OPENROUTER_API_KEY for embeddings"
+                )
+
+            base_url = os.getenv("OPENAI_BASE_URL")
+            if not base_url and os.getenv("OPENROUTER_API_KEY") and not os.getenv("OPENAI_API_KEY"):
+                base_url = "https://openrouter.ai/api/v1"
+
+            if base_url:
+                self.client = OpenAI(api_key=api_key, base_url=base_url)
+            else:
+                self.client = OpenAI(api_key=api_key)
+
+            logger.info(
+                f"Created EmbeddingManager for model: {self.model_name} (base_url={base_url or 'default'})"
+            )
         except Exception as e:
-            logger.error(f"Failed to initialize OpenAI backend: {e}")
+            logger.error(f"Failed to initialize embeddings backend: {e}")
             raise
 
     def _init_local(self):

--- a/cortex/llm_controllers/llm_controller.py
+++ b/cortex/llm_controllers/llm_controller.py
@@ -12,14 +12,36 @@ class BaseLLMController(ABC):
 
 class OpenAIController(BaseLLMController):
     def __init__(self, model: str = "gpt-4", api_key: Optional[str] = None):
+        """OpenAI-compatible chat controller.
+
+        Supports both:
+        - OpenAI direct (OPENAI_API_KEY)
+        - OpenRouter OpenAI-compatible proxy (OPENROUTER_API_KEY) via base_url
+
+        Env vars:
+        - OPENAI_API_KEY (preferred)
+        - OPENROUTER_API_KEY (fallback)
+        - OPENAI_BASE_URL (optional override)
+        """
         try:
             from openai import OpenAI
             self.model = model
+
             if api_key is None:
-                api_key = os.getenv('OPENAI_API_KEY')
+                api_key = os.getenv("OPENAI_API_KEY") or os.getenv("OPENROUTER_API_KEY")
             if api_key is None:
-                raise ValueError("OpenAI API key not found. Set OPENAI_API_KEY environment variable.")
-            self.client = OpenAI(api_key=api_key)
+                raise ValueError(
+                    "OpenAI-compatible API key not found. Set OPENAI_API_KEY or OPENROUTER_API_KEY."
+                )
+
+            base_url = os.getenv("OPENAI_BASE_URL")
+            if not base_url and os.getenv("OPENROUTER_API_KEY") and not os.getenv("OPENAI_API_KEY"):
+                base_url = "https://openrouter.ai/api/v1"
+
+            if base_url:
+                self.client = OpenAI(api_key=api_key, base_url=base_url)
+            else:
+                self.client = OpenAI(api_key=api_key)
         except ImportError:
             raise ImportError("OpenAI package not found. Install it with: pip install openai")
     

--- a/cortex/memory_system.py
+++ b/cortex/memory_system.py
@@ -34,7 +34,7 @@ class AgenticMemorySystem:
                  enable_background_processing: bool = True,
                  chroma_uri: str = DEFAULT_CHROMA_URI):  
         if api_key is None:
-            api_key = os.getenv("OPENAI_API_KEY")
+            api_key = os.getenv("OPENAI_API_KEY") or os.getenv("OPENROUTER_API_KEY")
         self.enable_smart_collections = enable_smart_collections
         self.memories = {}
         

--- a/integrations/openclaw/INTEGRATION_NOTES.md
+++ b/integrations/openclaw/INTEGRATION_NOTES.md
@@ -1,0 +1,65 @@
+# Integration Notes (Cortex-side)
+
+This document is for the Cortex maintainer integrating `integrations/openclaw`.
+
+## Key design points
+
+- The OpenClaw side “memory” concept is file-based (`MEMORY.md`, `memory/*.md`).
+- This adapter provides two canonical tools:
+  - `cortex_remember(content, context?, tags?)`
+  - `cortex_recall(query, temporal_weight?, date_range?, limit?)`
+- User/session isolation is done via `user_id` and `session_id` passed into every call.
+
+## Tool metadata
+
+`integrations/openclaw/tools.json` defines:
+
+- tool name/description
+- JSON-schema parameters
+- Python function import targets (`module:function`)
+- optional hook definitions
+
+Cortex needs a loader/registry to consume this metadata.
+
+### Suggestion: minimal loader
+
+Pseudo-code:
+
+```python
+import json
+import importlib
+
+spec = json.load(open("integrations/openclaw/tools.json"))
+
+for tool in spec["tools"]:
+    mod_path, fn_name = tool["function"].split(":")
+    fn = getattr(importlib.import_module(mod_path), fn_name)
+    register_tool(tool["name"], tool["description"], tool["parameters"], fn)
+```
+
+## Hooks
+
+The metadata includes:
+
+- `on_session_start` → calls `init_cortex_adapter(**kwargs)`
+- `on_conversation_turn` → calls `on_conversation_turn(user_message, agent_response, auto_detect=True)`
+
+If Cortex doesn’t support hooks, ignore this field.
+
+## API compatibility check
+
+The adapter assumes these methods exist:
+
+- `AgenticMemorySystem.add_note(...)` returning a memory id
+- `AgenticMemorySystem.search(...)` returning a list[dict]
+
+If Cortex differs:
+
+- Either adjust adapter to match actual API
+- Or add a small compatibility wrapper inside Cortex
+
+## Security / privacy
+
+- Ensure `user_id`/`session_id` are used as mandatory filters for search.
+- Avoid cross-user memory leakage.
+- Consider disabling auto-store hooks by default until audited.

--- a/integrations/openclaw/INTEGRATION_README.md
+++ b/integrations/openclaw/INTEGRATION_README.md
@@ -1,0 +1,126 @@
+# Cortex ↔ OpenClaw Integration (Proposed)
+
+This repo/patch is a **clean integration package** intended to be copied into the **Cortex** repository at:
+
+```
+cortex/integrations/openclaw/
+```
+
+It provides:
+
+- A Python adapter (`integrations/openclaw/adapter.py`) bridging OpenClaw-style tool calls to Cortex `AgenticMemorySystem`
+- Tool schemas (`integrations/openclaw/tools.json`) for registering `cortex_remember` and `cortex_recall`
+- Optional event hooks for auto-memory capture (`on_session_start`, `on_conversation_turn`)
+- A migration utility to import OpenClaw markdown memory (`MEMORY.md`, `memory/*.md`) into Cortex
+
+> Note: OpenClaw itself typically registers tools via a **TypeScript plugin**. This integration is specifically for
+> adding **OpenClaw support into Cortex** (i.e., Cortex exposing an adapter + tool metadata), as requested.
+
+---
+
+## 1) Quick copy into Cortex repo
+
+From the root of the Cortex repo:
+
+```bash
+mkdir -p integrations/openclaw
+# copy the contents of this repo into cortex/integrations/openclaw
+cp -R /path/to/this-repo/integrations/openclaw/* integrations/openclaw/
+```
+
+---
+
+## 2) What Cortex needs to provide / wire up
+
+### A) Ensure Cortex API compatibility
+
+This adapter expects Cortex to expose:
+
+- `from cortex.memory_system import AgenticMemorySystem`
+- `AgenticMemorySystem(...)
+- `AgenticMemorySystem.add_note(...) -> str` (memory id)
+- `AgenticMemorySystem.search(...) -> list[dict]`
+
+If Cortex uses different names/signatures, add a thin compatibility layer in Cortex or adjust the adapter.
+
+### B) Tool runner / registration
+
+`integrations/openclaw/tools.json` is **metadata**. Cortex needs a small loader that:
+
+- reads `tools.json`
+- imports the referenced functions, e.g.
+  - `integrations.openclaw.adapter:cortex_remember`
+  - `integrations.openclaw.adapter:cortex_recall`
+- exposes them through Cortex’s existing tool interface (whatever Cortex uses for “tools”)
+
+### C) Event hooks (optional)
+
+`tools.json` includes hooks:
+
+- `on_session_start` → `integrations.openclaw.adapter:init_cortex_adapter`
+- `on_conversation_turn` → `integrations.openclaw.adapter:on_conversation_turn`
+
+If Cortex doesn’t have a hook dispatcher yet, treat these as optional and implement later.
+
+---
+
+## 3) Configuration
+
+Environment variables referenced by docs/tool metadata:
+
+- `OPENAI_API_KEY` (required)
+- `CORTEX_CHROMA_HOST` (optional)
+- `CORTEX_CHROMA_PORT` (optional)
+
+> Important: `chroma_host/chroma_port` are accepted by the adapter constructor, but the current adapter does not forward
+> them into `AgenticMemorySystem`. If Cortex needs explicit host/port configuration, update the adapter once the Cortex
+> API is confirmed.
+
+---
+
+## 4) Example usage
+
+```python
+import os
+from integrations.openclaw.adapter import OpenClawCortexAdapter
+
+adapter = OpenClawCortexAdapter(
+    api_key=os.environ["OPENAI_API_KEY"],
+    user_id="openclaw_user_123",
+    session_id="main",
+)
+
+adapter.remember(
+    content="User prefers Python for backend work",
+    context="preferences.programming",
+    tags=["python", "backend"],
+)
+
+results = adapter.recall(
+    query="programming preferences",
+    temporal_weight=0.3,
+    limit=5,
+)
+print(results)
+```
+
+---
+
+## 5) Proposed next steps for Biswa
+
+1. Drop this into `cortex/integrations/openclaw/`
+2. Confirm `AgenticMemorySystem` API compatibility (add_note/search signatures)
+3. Add a minimal loader/registry in Cortex that reads `tools.json` and registers functions
+4. Decide whether to keep hooks in metadata or implement a Cortex hook dispatcher
+5. Add tests (see `tests/` suggestions)
+
+---
+
+## Notes
+
+This package originally arrived as a zip named “OpenClaw + Cortex Integration Package”.
+A small fix was applied:
+
+- Added a top-level `on_conversation_turn(...)` function (the metadata referenced it, but only a class method existed)
+- Adjusted `init_cortex_adapter` to return a JSON dict instead of a Python object
+- Added `__init__.py` so `integrations.openclaw` imports cleanly

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -1,0 +1,265 @@
+# OpenClaw + Cortex Integration
+
+> Integrate Prem Cortex memory system into OpenClaw AI agents
+
+## Overview
+
+This integration brings Cortex's advanced memory capabilities to OpenClaw agents:
+
+- **Dual-tier memory** (STM/LTM) replacing flat markdown files
+- **Temporal awareness** for time-based queries
+- **Memory evolution** with automatic linking
+- **Smart Collections** for domain organization
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                      OpenClaw Agent                          │
+├─────────────────────────────────────────────────────────────┤
+│  Existing Tools:          │  New Cortex Tools:              │
+│  - memory_search          │  - cortex_add                   │
+│  - memory_get             │  - cortex_search                │
+│  - read/write files       │  - cortex_evolve                │
+├─────────────────────────────────────────────────────────────┤
+│                    Cortex Adapter Layer                      │
+│  ┌─────────────────────────────────────────────────────┐    │
+│  │ AgenticMemorySystem                                  │    │
+│  │ - user_id = openclaw_user_id                        │    │
+│  │ - session_id = openclaw_session_key                 │    │
+│  │ - Auto-store on conversation events                  │    │
+│  └─────────────────────────────────────────────────────┘    │
+├─────────────────────────────────────────────────────────────┤
+│                     ChromaDB (Vector Store)                  │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Installation
+
+### Option 1: Add to Cortex repo (recommended for Biswa)
+
+```bash
+# In cortex repo
+mkdir -p integrations/openclaw
+cp -r ./* /path/to/cortex/integrations/openclaw/
+```
+
+### Option 2: Install as OpenClaw skill
+
+```bash
+# In openclaw workspace
+git clone https://github.com/prem-research/cortex.git skills/cortex
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `adapter.py` | OpenClaw ↔ Cortex bridge |
+| `tools.py` | Tool definitions for OpenClaw gateway |
+| `config.py` | Configuration management |
+| `SKILL.md` | OpenClaw skill instructions |
+
+## Quick Start
+
+```python
+from integrations.openclaw import OpenClawCortexAdapter
+
+# Initialize with OpenClaw context
+adapter = OpenClawCortexAdapter(
+    api_key=os.getenv("OPENAI_API_KEY"),
+    user_id="openclaw_user_123",
+    session_id="main",
+)
+
+# Store a memory (called automatically on significant events)
+adapter.remember(
+    content="User prefers Python for backend work",
+    context="preferences.programming",
+    tags=["python", "backend"]
+)
+
+# Search with temporal awareness
+results = adapter.recall(
+    query="programming preferences",
+    temporal_weight=0.3,  # 70% semantic, 30% recency
+    limit=5
+)
+
+# Search with date filter
+results = adapter.recall(
+    query="what did we discuss?",
+    date_range="yesterday",
+    limit=10
+)
+```
+
+## OpenClaw Tool Definitions
+
+Add to OpenClaw's tool registry:
+
+```json
+{
+  "tools": [
+    {
+      "name": "cortex_remember",
+      "description": "Store a memory with automatic analysis and linking",
+      "parameters": {
+        "content": { "type": "string", "required": true },
+        "context": { "type": "string" },
+        "tags": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    {
+      "name": "cortex_recall", 
+      "description": "Search memories with temporal awareness",
+      "parameters": {
+        "query": { "type": "string", "required": true },
+        "temporal_weight": { "type": "number", "default": 0.0 },
+        "date_range": { "type": "string" },
+        "limit": { "type": "integer", "default": 10 }
+      }
+    }
+  ]
+}
+```
+
+## Configuration
+
+### Environment Variables
+
+```bash
+# Required
+OPENAI_API_KEY=sk-...
+
+# Optional
+CORTEX_CHROMA_HOST=localhost
+CORTEX_CHROMA_PORT=8000
+CORTEX_STM_CAPACITY=100
+CORTEX_ENABLE_SMART_COLLECTIONS=true
+CORTEX_ENABLE_BACKGROUND_PROCESSING=true
+```
+
+### OpenClaw Gateway Config
+
+```yaml
+# In openclaw config
+memory:
+  provider: cortex
+  cortex:
+    chroma_host: localhost
+    chroma_port: 8000
+    stm_capacity: 100
+    smart_collections: true
+    background_processing: true
+```
+
+## Event Hooks
+
+OpenClaw can auto-store memories on events:
+
+```python
+# In adapter.py
+class OpenClawCortexAdapter:
+    
+    def on_conversation_turn(self, user_message: str, agent_response: str):
+        """Called after each conversation turn"""
+        # Store significant exchanges
+        if self._is_significant(user_message, agent_response):
+            self.remember(
+                content=f"User: {user_message}\nAgent: {agent_response}",
+                context="conversation",
+                time=datetime.now().isoformat()
+            )
+    
+    def on_user_preference(self, preference: str, value: str):
+        """Called when user expresses a preference"""
+        self.remember(
+            content=f"User preference: {preference} = {value}",
+            context="preferences",
+            tags=["preference", preference.lower()]
+        )
+    
+    def on_task_completed(self, task: str, result: str):
+        """Called when a task is completed"""
+        self.remember(
+            content=f"Completed task: {task}\nResult: {result}",
+            context="tasks",
+            tags=["task", "completed"]
+        )
+```
+
+## Migration from Markdown Memory
+
+For existing OpenClaw users with markdown memories:
+
+```python
+from integrations.openclaw import migrate_markdown_to_cortex
+
+# Migrate MEMORY.md and memory/*.md to Cortex
+migrate_markdown_to_cortex(
+    memory_dir="/path/to/openclaw/workspace",
+    adapter=adapter,
+    preserve_dates=True  # Extract dates from filenames
+)
+```
+
+## API Reference
+
+### OpenClawCortexAdapter
+
+#### `__init__(api_key, user_id, session_id, **kwargs)`
+
+Initialize the adapter.
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `api_key` | str | required | OpenAI API key |
+| `user_id` | str | required | OpenClaw user identifier |
+| `session_id` | str | "main" | Session identifier |
+| `stm_capacity` | int | 100 | Short-term memory capacity |
+| `enable_smart_collections` | bool | True | Enable domain organization |
+| `enable_background_processing` | bool | True | Async LTM processing |
+
+#### `remember(content, context=None, tags=None, time=None)`
+
+Store a memory.
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `content` | str | Memory content |
+| `context` | str | Domain context (e.g., "work.programming") |
+| `tags` | list[str] | Searchable tags |
+| `time` | str | ISO timestamp (default: now) |
+
+Returns: `str` - Memory ID
+
+#### `recall(query, temporal_weight=0.0, date_range=None, limit=10)`
+
+Search memories.
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `query` | str | Search query |
+| `temporal_weight` | float | 0.0-1.0, blend of recency vs semantic |
+| `date_range` | str | "yesterday", "last week", "2024-01", etc. |
+| `limit` | int | Max results |
+
+Returns: `list[dict]` - Ranked memory results with scores
+
+## Contributing
+
+1. Fork the Cortex repo
+2. Add this integration to `integrations/openclaw/`
+3. Submit PR with tests
+
+## Links
+
+- [OpenClaw](https://github.com/openclaw/openclaw)
+- [Prem Cortex](https://github.com/prem-research/cortex)
+- [OpenClaw Docs](https://docs.openclaw.ai)
+- [Prem AI](https://premai.io)
+
+## License
+
+MIT - Same as Cortex

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -1,0 +1,138 @@
+# Cortex Memory Skill
+
+> Advanced memory system for OpenClaw agents powered by Prem Cortex
+
+## Description
+
+This skill replaces or augments OpenClaw's default markdown-based memory with Cortex's cognitive memory architecture:
+
+- **Dual-tier memory**: Fast STM + persistent LTM (ChromaDB)
+- **Temporal awareness**: Query by time ("yesterday", "last week")
+- **Memory evolution**: Auto-linking and relationship building
+- **Smart Collections**: Domain-aware organization
+
+## Requirements
+
+- Python 3.11+
+- ChromaDB server running
+- OpenAI API key (or Ollama for self-hosted)
+
+## Setup
+
+### 1. Start ChromaDB
+
+```bash
+docker run -d -p 8000:8000 chromadb/chroma:latest
+```
+
+### 2. Set Environment Variables
+
+```bash
+export OPENAI_API_KEY=sk-...
+export CORTEX_CHROMA_HOST=localhost
+export CORTEX_CHROMA_PORT=8000
+```
+
+### 3. Install Cortex
+
+```bash
+pip install git+https://github.com/prem-research/cortex.git
+```
+
+## Usage
+
+### Storing Memories
+
+Use `cortex_remember` instead of writing to MEMORY.md:
+
+```
+User: Remember that I prefer Python for backend work
+Agent: [calls cortex_remember with content="User prefers Python for backend work", context="preferences.programming"]
+```
+
+### Searching Memories
+
+Use `cortex_recall` for intelligent search:
+
+```
+User: What did we discuss about the API project last week?
+Agent: [calls cortex_recall with query="API project", date_range="last week", temporal_weight=0.5]
+```
+
+### Temporal Queries
+
+The `temporal_weight` parameter controls recency vs relevance:
+
+- `0.0` = Pure semantic search (default)
+- `0.5` = Balanced
+- `1.0` = Pure recency (most recent first)
+
+### Date Ranges
+
+Supported formats:
+- Natural: `"yesterday"`, `"last week"`, `"last month"`
+- Year-Month: `"2024-01"` (January 2024)
+- RFC3339: `"2024-01-15T00:00:00Z"`
+
+## When to Use
+
+### Use Cortex When:
+- User asks about past conversations
+- User expresses preferences
+- Important decisions are made
+- Tasks are completed
+- User explicitly says "remember this"
+
+### Keep Using Files When:
+- Storing code snippets
+- Writing documentation
+- Managing config files
+- Anything that should be human-editable
+
+## Migration
+
+To migrate existing MEMORY.md to Cortex:
+
+```python
+from integrations.openclaw.adapter import migrate_markdown_to_cortex, OpenClawCortexAdapter
+
+adapter = OpenClawCortexAdapter(
+    api_key=os.getenv("OPENAI_API_KEY"),
+    user_id="user_123",
+)
+
+stats = migrate_markdown_to_cortex(
+    memory_dir="/path/to/workspace",
+    adapter=adapter,
+)
+print(f"Migrated {stats['migrated']} memories")
+```
+
+## Tool Reference
+
+### cortex_remember
+
+Store a memory with automatic analysis.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| content | string | Yes | What to remember |
+| context | string | No | Domain (e.g., "work.programming") |
+| tags | array | No | Searchable tags |
+
+### cortex_recall
+
+Search memories with temporal awareness.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| query | string | Yes | Search query |
+| temporal_weight | number | No | 0.0-1.0 recency weight |
+| date_range | string | No | Time filter |
+| limit | integer | No | Max results (default: 10) |
+
+## Links
+
+- [Prem Cortex](https://github.com/prem-research/cortex)
+- [OpenClaw](https://github.com/openclaw/openclaw)
+- [ChromaDB](https://www.trychroma.com/)

--- a/integrations/openclaw/TEST_PLAN.md
+++ b/integrations/openclaw/TEST_PLAN.md
@@ -1,0 +1,36 @@
+# Test plan (contract-level)
+
+> This is a suggested test plan; implement in Cortex’s test framework (pytest/unittest).
+
+## 1) Adapter initializes
+
+- Given a valid API key and user/session
+- When `OpenClawCortexAdapter(...)` is created
+- Then it should construct `AgenticMemorySystem` and not throw
+
+## 2) remember() stores
+
+- When `remember(content="x")`
+- Then it should call `AgenticMemorySystem.add_note` with:
+  - `user_id`, `session_id` present
+  - `time` in ISO format
+
+## 3) recall() searches
+
+- When `recall(query="x")`
+- Then it should call `AgenticMemorySystem.search` with:
+  - `user_id`, `session_id` present
+  - `limit` respected
+
+## 4) Hook wrappers
+
+- `init_cortex_adapter(...)` returns `{success: true}` and sets global adapter
+- `on_conversation_turn(...)` returns `{success: true, stored: bool, memory_id: ...}`
+
+## 5) Migration
+
+- Provide a temp dir with:
+  - `MEMORY.md`
+  - `memory/2026-02-10.md`
+- Run `migrate_markdown_to_cortex(..., preserve_dates=True)`
+- Assert `add_note` called expected number of times with expected contexts/tags

--- a/integrations/openclaw/__init__.py
+++ b/integrations/openclaw/__init__.py
@@ -1,0 +1,13 @@
+"""OpenClaw integration for Prem Cortex.
+
+This package provides an adapter layer and tool wrappers that let OpenClaw-style
+agents store and recall memories in Cortex.
+"""
+
+from .adapter import (
+    OpenClawCortexAdapter,
+    init_cortex_adapter,
+    cortex_remember,
+    cortex_recall,
+    migrate_markdown_to_cortex,
+)

--- a/integrations/openclaw/adapter.py
+++ b/integrations/openclaw/adapter.py
@@ -1,0 +1,519 @@
+"""
+OpenClaw ↔ Cortex Adapter
+
+Bridge between OpenClaw agent tools and Cortex memory system.
+"""
+
+import os
+from datetime import datetime
+from typing import Optional, List, Dict, Any
+
+from cortex.memory_system import AgenticMemorySystem
+
+
+class OpenClawCortexAdapter:
+    """
+    Adapter that wraps Cortex AgenticMemorySystem for OpenClaw agents.
+    
+    Provides:
+    - Simplified remember/recall API
+    - Automatic user/session context
+    - Event hooks for auto-storage
+    - Migration utilities
+    """
+    
+    def __init__(
+        self,
+        api_key: str,
+        user_id: str,
+        session_id: str = "main",
+        stm_capacity: int = 100,
+        enable_smart_collections: bool = True,
+        enable_background_processing: bool = True,
+        chroma_host: str = "localhost",
+        chroma_port: int = 8000,
+        model_name: str = "text-embedding-3-small",
+        llm_backend: str = "openai",
+    ):
+        """
+        Initialize the OpenClaw-Cortex adapter.
+        
+        Args:
+            api_key: OpenAI API key for embeddings and LLM
+            user_id: OpenClaw user identifier (for memory isolation)
+            session_id: Session identifier (default: "main")
+            stm_capacity: Short-term memory capacity
+            enable_smart_collections: Enable domain-aware collections
+            enable_background_processing: Enable async LTM processing
+            chroma_host: ChromaDB host
+            chroma_port: ChromaDB port
+            model_name: Embedding model name
+            llm_backend: LLM backend ("openai" or "ollama")
+        """
+        self.user_id = user_id
+        self.session_id = session_id
+        
+        # Initialize Cortex memory system
+        # NOTE: Chroma host/port are accepted by this adapter for consistency
+        # with OpenClaw-style configuration, but the underlying Cortex API
+        # may or may not use them depending on its implementation.
+        self.memory = AgenticMemorySystem(
+            api_key=api_key,
+            stm_capacity=stm_capacity,
+            enable_smart_collections=enable_smart_collections,
+            enable_background_processing=enable_background_processing,
+            model_name=model_name,
+            llm_backend=llm_backend,
+        )
+        
+        # Significance detection keywords
+        self._significant_keywords = [
+            "prefer", "like", "hate", "always", "never",
+            "remember", "important", "decision", "agreed",
+            "todo", "task", "deadline", "meeting", "project"
+        ]
+    
+    def remember(
+        self,
+        content: str,
+        context: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        time: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """
+        Store a memory with automatic analysis.
+        
+        Args:
+            content: Memory content to store
+            context: Domain context (e.g., "work.programming.python")
+            tags: Searchable tags
+            time: ISO timestamp (default: now)
+            metadata: Additional metadata
+            
+        Returns:
+            Memory ID
+        """
+        return self.memory.add_note(
+            content=content,
+            user_id=self.user_id,
+            session_id=self.session_id,
+            context=context,
+            tags=tags,
+            time=time or datetime.now().astimezone().isoformat(),
+            **(metadata or {}),
+        )
+    
+    def recall(
+        self,
+        query: str,
+        temporal_weight: float = 0.0,
+        date_range: Optional[str] = None,
+        memory_source: str = "all",
+        limit: int = 10,
+        context: Optional[str] = None,
+        where_filter: Optional[Dict[str, Any]] = None,
+    ) -> List[Dict[str, Any]]:
+        """
+        Search memories with temporal awareness.
+        
+        Args:
+            query: Search query
+            temporal_weight: 0.0-1.0, blend of recency (1.0) vs semantic (0.0)
+            date_range: Filter by date ("yesterday", "last week", "2024-01", etc.)
+            memory_source: "stm", "ltm", or "all"
+            limit: Maximum results to return
+            context: Context for relevance boosting
+            where_filter: Metadata filter
+            
+        Returns:
+            List of memory results with scores
+        """
+        results = self.memory.search(
+            query=query,
+            user_id=self.user_id,
+            session_id=self.session_id,
+            temporal_weight=temporal_weight,
+            date_range=date_range,
+            memory_source=memory_source,
+            limit=limit,
+            context=context,
+            where_filter=where_filter,
+        )
+        
+        # Format results for OpenClaw consumption
+        return [
+            {
+                "content": r.get("content", ""),
+                "score": r.get("score", 0.0),
+                "recency_score": r.get("recency_score"),
+                "temporal_weighted": r.get("temporal_weighted", False),
+                "context": r.get("context"),
+                "tags": r.get("tags", []),
+                "time": r.get("time"),
+                "id": r.get("id"),
+            }
+            for r in results
+        ]
+    
+    # ─────────────────────────────────────────────────────────────
+    # Event Hooks - Called by OpenClaw on various events
+    # ─────────────────────────────────────────────────────────────
+    
+    def on_conversation_turn(
+        self,
+        user_message: str,
+        agent_response: str,
+        auto_detect: bool = True,
+    ) -> Optional[str]:
+        """
+        Called after each conversation turn.
+        Stores significant exchanges automatically.
+        
+        Args:
+            user_message: The user's message
+            agent_response: The agent's response
+            auto_detect: Whether to auto-detect significance
+            
+        Returns:
+            Memory ID if stored, None if skipped
+        """
+        if auto_detect and not self._is_significant(user_message, agent_response):
+            return None
+        
+        content = f"User: {user_message}\nAssistant: {agent_response}"
+        return self.remember(
+            content=content,
+            context="conversation",
+            tags=["conversation", "exchange"],
+        )
+    
+    def on_user_preference(self, preference: str, value: Any) -> str:
+        """
+        Called when user expresses a preference.
+        
+        Args:
+            preference: Preference name (e.g., "code_editor")
+            value: Preference value (e.g., "VS Code")
+            
+        Returns:
+            Memory ID
+        """
+        return self.remember(
+            content=f"User preference: {preference} = {value}",
+            context="preferences",
+            tags=["preference", preference.lower().replace(" ", "_")],
+        )
+    
+    def on_task_completed(self, task: str, result: str) -> str:
+        """
+        Called when a task is completed.
+        
+        Args:
+            task: Task description
+            result: Task result/outcome
+            
+        Returns:
+            Memory ID
+        """
+        return self.remember(
+            content=f"Completed task: {task}\nResult: {result}",
+            context="tasks",
+            tags=["task", "completed"],
+        )
+    
+    def on_decision_made(self, decision: str, reasoning: str = "") -> str:
+        """
+        Called when a decision is made.
+        
+        Args:
+            decision: The decision made
+            reasoning: Optional reasoning behind it
+            
+        Returns:
+            Memory ID
+        """
+        content = f"Decision: {decision}"
+        if reasoning:
+            content += f"\nReasoning: {reasoning}"
+        
+        return self.remember(
+            content=content,
+            context="decisions",
+            tags=["decision"],
+        )
+    
+    def on_explicit_remember(self, content: str, context: str = "explicit") -> str:
+        """
+        Called when user explicitly asks to remember something.
+        
+        Args:
+            content: What to remember
+            context: Optional context category
+            
+        Returns:
+            Memory ID
+        """
+        return self.remember(
+            content=content,
+            context=context,
+            tags=["explicit", "user_requested"],
+        )
+    
+    # ─────────────────────────────────────────────────────────────
+    # Utility Methods
+    # ─────────────────────────────────────────────────────────────
+    
+    def _is_significant(self, user_message: str, agent_response: str) -> bool:
+        """
+        Detect if a conversation turn is significant enough to store.
+        """
+        combined = f"{user_message} {agent_response}".lower()
+        
+        # Check for significant keywords
+        for keyword in self._significant_keywords:
+            if keyword in combined:
+                return True
+        
+        # Check for questions that indicate preferences/decisions
+        if any(q in user_message.lower() for q in ["do you remember", "what did we", "last time"]):
+            return True
+        
+        # Check message length (longer exchanges often more significant)
+        if len(user_message) > 200 or len(agent_response) > 500:
+            return True
+        
+        return False
+    
+    def get_recent_context(self, limit: int = 5) -> str:
+        """
+        Get recent memories as context string for prompts.
+        
+        Args:
+            limit: Number of recent memories
+            
+        Returns:
+            Formatted context string
+        """
+        results = self.recall(
+            query="",
+            memory_source="stm",
+            limit=limit,
+            temporal_weight=1.0,  # Pure recency
+        )
+        
+        if not results:
+            return ""
+        
+        context_lines = ["Recent context:"]
+        for r in results:
+            context_lines.append(f"- {r['content'][:200]}...")
+        
+        return "\n".join(context_lines)
+
+
+# ─────────────────────────────────────────────────────────────────
+# Migration Utilities
+# ─────────────────────────────────────────────────────────────────
+
+def migrate_markdown_to_cortex(
+    memory_dir: str,
+    adapter: OpenClawCortexAdapter,
+    preserve_dates: bool = True,
+) -> Dict[str, int]:
+    """
+    Migrate existing OpenClaw markdown memories to Cortex.
+    
+    Args:
+        memory_dir: Path to OpenClaw workspace (containing MEMORY.md, memory/)
+        adapter: Initialized OpenClawCortexAdapter
+        preserve_dates: Extract dates from filenames for daily logs
+        
+    Returns:
+        Migration stats {"migrated": N, "skipped": N, "errors": N}
+    """
+    import re
+    from pathlib import Path
+    
+    stats = {"migrated": 0, "skipped": 0, "errors": 0}
+    workspace = Path(memory_dir)
+    
+    # Migrate MEMORY.md (long-term curated memories)
+    memory_md = workspace / "MEMORY.md"
+    if memory_md.exists():
+        try:
+            content = memory_md.read_text()
+            sections = _parse_markdown_sections(content)
+            
+            for section_title, section_content in sections.items():
+                if section_content.strip():
+                    adapter.remember(
+                        content=section_content,
+                        context=f"memory.{section_title.lower().replace(' ', '_')}",
+                        tags=["migrated", "memory_md"],
+                    )
+                    stats["migrated"] += 1
+        except Exception as e:
+            print(f"Error migrating MEMORY.md: {e}")
+            stats["errors"] += 1
+    
+    # Migrate memory/*.md (daily logs)
+    memory_folder = workspace / "memory"
+    if memory_folder.exists():
+        for md_file in sorted(memory_folder.glob("*.md")):
+            try:
+                content = md_file.read_text()
+                
+                # Extract date from filename (e.g., 2024-01-15.md)
+                date_match = re.match(r"(\d{4}-\d{2}-\d{2})", md_file.stem)
+                time = None
+                if preserve_dates and date_match:
+                    time = f"{date_match.group(1)}T12:00:00+00:00"
+                
+                # Parse sections within the daily log
+                sections = _parse_markdown_sections(content)
+                
+                for section_title, section_content in sections.items():
+                    if section_content.strip():
+                        adapter.remember(
+                            content=section_content,
+                            context=f"daily.{section_title.lower().replace(' ', '_')}",
+                            tags=["migrated", "daily_log", md_file.stem],
+                            time=time,
+                        )
+                        stats["migrated"] += 1
+                        
+            except Exception as e:
+                print(f"Error migrating {md_file}: {e}")
+                stats["errors"] += 1
+    
+    return stats
+
+
+def _parse_markdown_sections(content: str) -> Dict[str, str]:
+    """
+    Parse markdown into sections by headers.
+    """
+    import re
+    
+    sections = {}
+    current_section = "general"
+    current_content = []
+    
+    for line in content.split("\n"):
+        header_match = re.match(r"^#+\s+(.+)$", line)
+        if header_match:
+            # Save previous section
+            if current_content:
+                sections[current_section] = "\n".join(current_content).strip()
+            current_section = header_match.group(1)
+            current_content = []
+        else:
+            current_content.append(line)
+    
+    # Save last section
+    if current_content:
+        sections[current_section] = "\n".join(current_content).strip()
+    
+    return sections
+
+
+# ─────────────────────────────────────────────────────────────────
+# OpenClaw Tool Functions (for gateway registration)
+# ─────────────────────────────────────────────────────────────────
+
+# Global adapter instance (initialized by OpenClaw gateway)
+_adapter: Optional[OpenClawCortexAdapter] = None
+
+
+def init_cortex_adapter(**kwargs) -> Dict[str, Any]:
+    """OpenClaw hook: initialize the global Cortex adapter.
+
+    Returns a small status object so tool/hook runners that expect JSON don't
+    attempt to serialize a complex Python object.
+    """
+    global _adapter
+    _adapter = OpenClawCortexAdapter(**kwargs)
+    return {"success": True}
+
+
+def on_conversation_turn(
+    user_message: str,
+    agent_response: str,
+    auto_detect: bool = True,
+) -> Dict[str, Any]:
+    """OpenClaw hook: store significant conversation exchanges.
+
+    This is a thin wrapper around the adapter instance method.
+    """
+    if not _adapter:
+        return {"success": False, "error": "Cortex adapter not initialized"}
+
+    try:
+        memory_id = _adapter.on_conversation_turn(
+            user_message=user_message,
+            agent_response=agent_response,
+            auto_detect=auto_detect,
+        )
+        return {"success": True, "memory_id": memory_id, "stored": bool(memory_id)}
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+
+def cortex_remember(
+    content: str,
+    context: Optional[str] = None,
+    tags: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """
+    OpenClaw tool: Store a memory.
+    
+    Args:
+        content: What to remember
+        context: Domain context (e.g., "work.programming")
+        tags: Searchable tags
+        
+    Returns:
+        {"success": True, "memory_id": "..."}
+    """
+    if not _adapter:
+        return {"success": False, "error": "Cortex adapter not initialized"}
+    
+    try:
+        memory_id = _adapter.remember(content=content, context=context, tags=tags)
+        return {"success": True, "memory_id": memory_id}
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+
+def cortex_recall(
+    query: str,
+    temporal_weight: float = 0.0,
+    date_range: Optional[str] = None,
+    limit: int = 10,
+) -> Dict[str, Any]:
+    """
+    OpenClaw tool: Search memories.
+    
+    Args:
+        query: Search query
+        temporal_weight: 0.0 (semantic) to 1.0 (recency)
+        date_range: "yesterday", "last week", "2024-01", etc.
+        limit: Max results
+        
+    Returns:
+        {"success": True, "results": [...]}
+    """
+    if not _adapter:
+        return {"success": False, "error": "Cortex adapter not initialized"}
+    
+    try:
+        results = _adapter.recall(
+            query=query,
+            temporal_weight=temporal_weight,
+            date_range=date_range,
+            limit=limit,
+        )
+        return {"success": True, "results": results, "count": len(results)}
+    except Exception as e:
+        return {"success": False, "error": str(e)}

--- a/integrations/openclaw/setup.sh
+++ b/integrations/openclaw/setup.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# OpenClaw + Cortex Integration Setup
+# Run this script to set up the integration
+
+set -e
+
+echo "🧠 OpenClaw + Cortex Integration Setup"
+echo "========================================"
+
+# Check Python version
+PYTHON_VERSION=$(python3 --version 2>&1 | grep -oP '3\.\d+')
+PYTHON_MAJOR=$(echo $PYTHON_VERSION | cut -d. -f1)
+PYTHON_MINOR=$(echo $PYTHON_VERSION | cut -d. -f2)
+
+if [ "$PYTHON_MAJOR" -lt 3 ] || ([ "$PYTHON_MAJOR" -eq 3 ] && [ "$PYTHON_MINOR" -lt 11 ]); then
+    echo "❌ Python 3.11+ required (found: $PYTHON_VERSION)"
+    exit 1
+fi
+echo "✅ Python $PYTHON_VERSION"
+
+# Check for OpenAI API key
+if [ -z "$OPENAI_API_KEY" ]; then
+    echo "⚠️  OPENAI_API_KEY not set"
+    echo "   Set it with: export OPENAI_API_KEY=sk-..."
+else
+    echo "✅ OPENAI_API_KEY configured"
+fi
+
+# Install Cortex
+echo ""
+echo "📦 Installing Cortex..."
+pip install git+https://github.com/prem-research/cortex.git --quiet
+
+# Check if ChromaDB is running
+echo ""
+echo "🔍 Checking ChromaDB..."
+CHROMA_HOST=${CORTEX_CHROMA_HOST:-localhost}
+CHROMA_PORT=${CORTEX_CHROMA_PORT:-8000}
+
+if curl -s "http://$CHROMA_HOST:$CHROMA_PORT/api/v1/heartbeat" > /dev/null 2>&1; then
+    echo "✅ ChromaDB running at $CHROMA_HOST:$CHROMA_PORT"
+else
+    echo "⚠️  ChromaDB not running at $CHROMA_HOST:$CHROMA_PORT"
+    echo ""
+    echo "   Start ChromaDB with Docker:"
+    echo "   docker run -d -p 8000:8000 chromadb/chroma:latest"
+    echo ""
+    echo "   Or with Poetry (in cortex repo):"
+    echo "   poetry run chroma run --host localhost --port 8000"
+    echo ""
+    
+    read -p "   Start ChromaDB with Docker now? [y/N] " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        echo "   Starting ChromaDB..."
+        docker run -d --name chromadb -p 8000:8000 chromadb/chroma:latest
+        sleep 3
+        if curl -s "http://$CHROMA_HOST:$CHROMA_PORT/api/v1/heartbeat" > /dev/null 2>&1; then
+            echo "   ✅ ChromaDB started"
+        else
+            echo "   ❌ Failed to start ChromaDB"
+            exit 1
+        fi
+    fi
+fi
+
+# Test import
+echo ""
+echo "🧪 Testing import..."
+python3 -c "from cortex.memory_system import AgenticMemorySystem; print('✅ Cortex imported successfully')" 2>/dev/null || {
+    echo "❌ Failed to import Cortex"
+    exit 1
+}
+
+# Summary
+echo ""
+echo "========================================"
+echo "✅ Setup complete!"
+echo ""
+echo "Next steps:"
+echo "1. Ensure OPENAI_API_KEY is set"
+echo "2. Ensure ChromaDB is running"
+echo "3. Import the adapter in your OpenClaw config:"
+echo ""
+echo "   from integrations.openclaw.adapter import OpenClawCortexAdapter"
+echo "   adapter = OpenClawCortexAdapter("
+echo "       api_key=os.getenv('OPENAI_API_KEY'),"
+echo "       user_id='your_user_id',"
+echo "   )"
+echo ""
+echo "📚 See README.md for full documentation"
+echo "🔗 Cortex repo: https://github.com/prem-research/cortex"
+echo "🦞 OpenClaw repo: https://github.com/openclaw/openclaw"

--- a/integrations/openclaw/tools.json
+++ b/integrations/openclaw/tools.json
@@ -1,0 +1,154 @@
+{
+  "name": "cortex-memory",
+  "version": "1.0.0",
+  "description": "Advanced memory tools powered by Prem Cortex",
+  "author": "OpenClaw + Prem AI",
+  "license": "MIT",
+  "repository": "https://github.com/prem-research/cortex",
+  "requirements": {
+    "python": ">=3.11",
+    "packages": ["cortex", "chromadb"],
+    "services": {
+      "chromadb": {
+        "host": "${CORTEX_CHROMA_HOST:-localhost}",
+        "port": "${CORTEX_CHROMA_PORT:-8000}"
+      }
+    },
+    "env": ["OPENAI_API_KEY"]
+  },
+  "tools": [
+    {
+      "name": "cortex_remember",
+      "description": "Store a memory with automatic semantic analysis, keyword extraction, and relationship linking. Use when user expresses preferences, makes decisions, completes tasks, or explicitly asks to remember something.",
+      "function": "integrations.openclaw.adapter:cortex_remember",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "string",
+            "description": "The memory content to store"
+          },
+          "context": {
+            "type": "string",
+            "description": "Domain context for organization (e.g., 'work.programming', 'personal.health', 'project.api')"
+          },
+          "tags": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Searchable tags for the memory"
+          }
+        },
+        "required": ["content"]
+      },
+      "returns": {
+        "type": "object",
+        "properties": {
+          "success": { "type": "boolean" },
+          "memory_id": { "type": "string" },
+          "error": { "type": "string" }
+        }
+      }
+    },
+    {
+      "name": "cortex_recall",
+      "description": "Search memories with semantic understanding and temporal awareness. Supports natural date ranges ('yesterday', 'last week') and recency weighting. Use for retrieving past conversations, preferences, decisions, or any stored information.",
+      "function": "integrations.openclaw.adapter:cortex_recall",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Search query (semantic search)"
+          },
+          "temporal_weight": {
+            "type": "number",
+            "minimum": 0.0,
+            "maximum": 1.0,
+            "default": 0.0,
+            "description": "Balance between semantic relevance (0.0) and recency (1.0). Use 0.5+ for time-sensitive queries."
+          },
+          "date_range": {
+            "type": "string",
+            "description": "Filter by date: 'yesterday', 'last week', 'last month', '2024-01', or RFC3339 timestamp"
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 50,
+            "default": 10,
+            "description": "Maximum number of results"
+          }
+        },
+        "required": ["query"]
+      },
+      "returns": {
+        "type": "object",
+        "properties": {
+          "success": { "type": "boolean" },
+          "results": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "content": { "type": "string" },
+                "score": { "type": "number" },
+                "recency_score": { "type": "number" },
+                "context": { "type": "string" },
+                "tags": { "type": "array" },
+                "time": { "type": "string" },
+                "id": { "type": "string" }
+              }
+            }
+          },
+          "count": { "type": "integer" },
+          "error": { "type": "string" }
+        }
+      }
+    }
+  ],
+  "hooks": {
+    "on_conversation_turn": {
+      "description": "Auto-store significant conversation exchanges",
+      "function": "integrations.openclaw.adapter:on_conversation_turn",
+      "enabled": true,
+      "config": {
+        "auto_detect_significance": true,
+        "min_message_length": 50
+      }
+    },
+    "on_session_start": {
+      "description": "Initialize Cortex adapter for the session",
+      "function": "integrations.openclaw.adapter:init_cortex_adapter"
+    }
+  },
+  "config_schema": {
+    "type": "object",
+    "properties": {
+      "stm_capacity": {
+        "type": "integer",
+        "default": 100,
+        "description": "Short-term memory capacity"
+      },
+      "enable_smart_collections": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable domain-aware memory organization"
+      },
+      "enable_background_processing": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable async LTM processing"
+      },
+      "auto_store_conversations": {
+        "type": "boolean",
+        "default": true,
+        "description": "Automatically store significant conversations"
+      },
+      "embedding_model": {
+        "type": "string",
+        "default": "text-embedding-3-small",
+        "description": "Embedding model for semantic search"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds integrations/openclaw adapter + tool metadata.

Also adds OpenRouter support as an OpenAI-compatible backend (uses OPENROUTER_API_KEY when OPENAI_API_KEY is absent; defaults OPENAI_BASE_URL to https://openrouter.ai/api/v1).

Fixes API auth 500s by pinning bcrypt<4.1 for passlib compatibility and adding explicit bcrypt password length validation (72-byte limit).

Tested locally: Chroma (no docker), Postgres, API /health/cortex, /auth/register+login, /memory/add+search.